### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "main.py"

--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ Learning Python as I go, so pardon the ugly code and style.
  †) These programs are ugly hacks and shouldn't been consider when reviewing my code for constructive criticism.
 ††) Massive clean-up refactoring needed
  
+[![Run on Repl.it](https://repl.it/badge/github/dnabre/advent_2019)](https://repl.it/github/dnabre/advent_2019)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dnabre/advent2019).